### PR TITLE
Add xgettext simulator

### DIFF
--- a/po/Makefile.in
+++ b/po/Makefile.in
@@ -59,10 +59,14 @@ TARGET = $(MO_FILES)
 all : $(TARGET)
 
 $(PACKAGE).pot : $(POTFILES)
-	xgettext -d$(PACKAGE) -LScheme -k'$$$$' -o$(PACKAGE).pot \
-	         --copyright-holder='Shiro Kawai' \
-	         --msgid-bugs-address='@PACKAGE_BUGREPORT@' \
-	         $(POTFILES)
+	if [ -n "$(XGETTEXT_SIM)" ]; then                            \
+	    gosh xgettext-sim.scm -o $(PACKAGE).pot $(POTFILES);     \
+	else                                                         \
+	    xgettext -d$(PACKAGE) -LScheme -k'$$$$' -o$(PACKAGE).pot \
+	             --copyright-holder='Shiro Kawai'                \
+	             --msgid-bugs-address='@PACKAGE_BUGREPORT@'      \
+	             $(POTFILES);                                    \
+	fi
 
 update-po: $(PACKAGE).pot
 	for lingua in $(ALL_LINGUAS); do \

--- a/po/xgettext-sim.scm
+++ b/po/xgettext-sim.scm
@@ -1,0 +1,155 @@
+;; -*- coding: utf-8 -*-
+;;
+;; xgettext-sim.scm
+;; 2018-10-6 v1.01
+;;
+;; Usage:
+;;   gosh xgettext-sim.scm -o outfile infile1 infile2 ...
+;;
+(use gauche.parseopt)
+(use srfi-19)
+
+(define-class <trans-item> ()
+  ((file-info     :init-value '())
+   (msgid         :init-value "")
+   (text-data     :init-value '())
+   (scheme-format :init-value #f)
+   ))
+
+(define trans-item-hash (make-hash-table 'equal?))
+(define trans-item-list '())
+
+;; check scheme format string (incomplete)
+(define (scheme-format-string? str)
+  (cond
+   ;; heuristic pattern is here (incomplete)
+   ((#/^\"<h2>Text Formatting Rules<\/h2>/ str)
+    #f)
+   ;; check scheme format string (incomplete)
+   (else
+    (guard (exc (else #t)) (format str) #f))))
+
+(define (generate-outdata infile)
+  (define line-no         0)
+  (define multi-line-item #f)
+  (for-each
+   (lambda (line)
+     (inc! line-no)
+     (cond
+      ;; end of multi-line item
+      ;;   check double quote (not escaped)
+      ((and multi-line-item (#/(?<!\\)(?:\\\\)*\"/ line))
+       => (lambda (m)
+            (let1 last-str (string-copy line 0 (rxmatch-start m))
+              (set!  (~ multi-line-item 'msgid)
+                     (string-append (~ multi-line-item 'msgid) last-str "\""))
+              (push! (~ multi-line-item 'text-data) #"\"~last-str\"")
+              (push! (~ multi-line-item 'text-data) "msgstr \"\"")
+              (set!  (~ multi-line-item 'scheme-format)
+                     (scheme-format-string? (~ multi-line-item 'msgid)))
+              (hash-table-put! trans-item-hash
+                               (~ multi-line-item 'msgid)
+                               multi-line-item)
+              (set! multi-line-item #f))))
+
+      ;; middle of multi-line item
+      (multi-line-item
+       (set! (~ multi-line-item 'msgid)
+             (string-append (~ multi-line-item 'msgid) line "\\n"))
+       (push! (~ multi-line-item 'text-data) #"\"~line\\n\""))
+
+      ;; single-line item
+      ;;   ($$      "data"
+      ;;   (gettext "data"
+      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|.)*\")/ line)
+       => (lambda (m)
+            (let1 data1 (rxmatch-substring m 1)
+              (cond
+               ((hash-table-get trans-item-hash data1 #f)
+                => (lambda (item)
+                     (push! (~ item 'file-info) (list infile line-no))))
+               (else
+                (let1 item (make <trans-item>)
+                  (push! (~ item 'file-info) (list infile line-no))
+                  (set!  (~ item 'msgid) data1)
+                  (push! (~ item 'text-data) #"msgid ~data1")
+                  (push! (~ item 'text-data) "msgstr \"\"")
+                  (set!  (~ item 'scheme-format) (scheme-format-string? data1))
+                  (hash-table-put! trans-item-hash data1 item)
+                  (push! trans-item-list item)))))))
+
+      ;; start of multi-line item
+      ;;   ($$      "data ...
+      ;;   (gettext "data ...
+      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|.)*)$/ line)
+       => (lambda (m)
+            (let1 data1 (rxmatch-substring m 1)
+              (cond
+               ((hash-table-get trans-item-hash data1 #f)
+                => (lambda (item)
+                     (push! (~ item 'file-info) (list infile line-no))))
+               (else
+                (let1 item (make <trans-item>)
+                  (set! multi-line-item item)
+                  (push! (~ item 'file-info) (list infile line-no))
+                  (set!  (~ item 'msgid) (string-append data1 "\\n"))
+                  (push! (~ item 'text-data) "msgid \"\"")
+                  (push! (~ item 'text-data) #"~data1\\n\"")
+                  ;(set!  (~ item 'scheme-format) (scheme-format-string? data1))
+                  ;(hash-table-put! trans-item-hash data1 item)
+                  (push! trans-item-list item)))))))))
+
+   (generator->lseq read-line)))
+
+(define (generate-outfile infiles outfile)
+  ;; generate data
+  (for-each
+   (lambda (infile)
+     (with-input-from-file infile
+       (lambda () (generate-outdata infile))))
+   infiles)
+  ;; output data
+  (with-output-to-file outfile
+    (lambda ()
+      ;; header
+      (print "#, fuzzy")
+      (print "msgid \"\"")
+      (print "msgstr \"\"")
+      (print "\"POT-Creation-Date: "
+             (date->string (current-date) "~Y-~m-~d ~H:~M~z")
+             "\\n\"")
+      (print "\"MIME-Version: 1.0\\n\"")
+      (print "\"Content-Type: text/plain; charset=euc-jp\\n\"")
+      (print "\"Content-Transfer-Encoding: 8bit\\n\"")
+      ;; items
+      (for-each
+       (lambda (item)
+         (print)
+         (format #t "#:")
+         (for-each (lambda (finfo)
+                     (format #t " ~a:~d" (car finfo) (cadr finfo)))
+                   (reverse (~ item 'file-info)))
+         (print)
+         (when (~ item 'scheme-format)
+           (print "#, scheme-format"))
+         (for-each (lambda (tdata)
+                     (print tdata))
+                   (reverse (~ item 'text-data))))
+       (reverse trans-item-list)))))
+
+(define (usage out code)
+  (display "Usage: gosh xgettext-sim.scm -o outfile infile1 infile2 ...\n" out)
+  (exit code))
+
+(define (main args)
+  (let-args (cdr args)
+      ([outfile "o|output=s"]
+       [else (opt . _)
+             (display #"Unknown option: ~opt\n" (current-error-port))
+             (usage (current-error-port) 1)]
+       . infiles)
+    (unless (and infiles outfile)
+      (usage (current-error-port) 1))
+    (generate-outfile infiles outfile)
+    0))
+

--- a/po/xgettext-sim.scm
+++ b/po/xgettext-sim.scm
@@ -1,7 +1,7 @@
 ;; -*- coding: utf-8 -*-
 ;;
 ;; xgettext-sim.scm
-;; 2018-10-6 v1.01
+;; 2018-10-7 v1.02
 ;;
 ;; Usage:
 ;;   gosh xgettext-sim.scm -o outfile infile1 infile2 ...
@@ -61,7 +61,7 @@
       ;; single-line item
       ;;   ($$      "data"
       ;;   (gettext "data"
-      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|.)*\")/ line)
+      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|[^\"])*\")/ line)
        => (lambda (m)
             (let1 data1 (rxmatch-substring m 1)
               (cond
@@ -81,7 +81,7 @@
       ;; start of multi-line item
       ;;   ($$      "data ...
       ;;   (gettext "data ...
-      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|.)*)$/ line)
+      ((#/\((?:$$|gettext)\s*(\"(?:(?<!\\)(?:\\\\)*\\\"|[^\"])*)$/ line)
        => (lambda (m)
             (let1 data1 (rxmatch-substring m 1)
               (cond


### PR DESCRIPTION
MSYS2 の xgettext (v0.19.8.1) では、
Gauche のスクリプトから翻訳データをうまく抽出できなかったため、
xgettext-sim.scm を作成してみました。
(ただ、まじめに解析していないため、誤ったデータを抽出する可能性があります)

xgettext-sim.scm を使用する場合は、以下のようにします。
```
cd po
rm WiLiKi.pot
XGETTEXT_SIM=1 make update-po
```

これで、WiLiKi.pot が作成されて、各 po ファイルにマージされます。
あとは make install でインストールできます。

＜補足＞
オリジナルの xgettext は、
scheme の format 文字列を検出すると、
`#, scheme-format` という目印の行を出力するようになっています。
(これによって、翻訳時の語順の入れ替えに対応しているようです)

しかし、xgettext-sim.scm では、
その検出アルゴリズムをうまく再現できなかったため、
一部、実際の文字列を埋め込んでヒューリスティックに対応しています。。。
(slib の format の仕様と同じらしいが、何か違う気もする。。。)
