### PR TITLE
Workaround for xgettext

### DIFF
--- a/po/Makefile.in
+++ b/po/Makefile.in
@@ -30,19 +30,21 @@ MO_FILES = $(addsuffix .gmo,$(ALL_LINGUAS))
 
 MSGDIR = "$(DESTDIR)$(datadir)/locale/$$lingua/LC_MESSAGES/"
 
-POTFILES = $(top_srcdir)/src/wiliki.scm \
-           $(top_srcdir)/src/wiliki/db.scm \
-           $(top_srcdir)/src/wiliki/edit.scm \
-           $(top_srcdir)/src/wiliki/format.scm \
-           $(top_srcdir)/src/wiliki/history.scm \
-           $(top_srcdir)/src/wiliki/log.scm \
-           $(top_srcdir)/src/wiliki/macro.scm \
-           $(top_srcdir)/src/wiliki/page.scm \
-           $(top_srcdir)/src/wiliki/parse.scm \
-           $(top_srcdir)/src/wiliki/pasttime.scm \
-           $(top_srcdir)/src/wiliki/rss.scm \
-           $(top_srcdir)/src/wiliki/rssmix.scm \
-           $(top_srcdir)/src/wiliki/util.scm
+POTFILES = src/wiliki.scm \
+           src/wiliki/db.scm \
+           src/wiliki/edit.scm \
+           src/wiliki/format.scm \
+           src/wiliki/history.scm \
+           src/wiliki/log.scm \
+           src/wiliki/macro.scm \
+           src/wiliki/page.scm \
+           src/wiliki/parse.scm \
+           src/wiliki/pasttime.scm \
+           src/wiliki/rss.scm \
+           src/wiliki/rssmix.scm \
+           src/wiliki/util.scm
+
+CONVDIR = conv1001
 
 # Module-specific stuff
 PACKAGE   = WiLiKi
@@ -58,13 +60,22 @@ TARGET = $(MO_FILES)
 
 all : $(TARGET)
 
-$(PACKAGE).pot : $(POTFILES)
+# NB: xgettext doesn't recognize Gauche's extensional syntax.
+# So we replace them before processing.
+generate-pot:
+	for f in $(POTFILES); do                               \
+	  mkdir -p `dirname "$(CONVDIR)/$$f"`;                 \
+	  cp -f $(top_srcdir)/$$f $(CONVDIR)/$$f;              \
+	  sed -i -e 's@#"@"@g' $(CONVDIR)/$$f;                 \
+	  sed -i -E 's@#/(\\/|[^/])*/i?@#//@g' $(CONVDIR)/$$f; \
+	done
 	xgettext -d$(PACKAGE) -LScheme -k'$$$$' -o$(PACKAGE).pot \
 	         --copyright-holder='Shiro Kawai' \
 	         --msgid-bugs-address='@PACKAGE_BUGREPORT@' \
-	         $(POTFILES)
+	         $(POTFILES:%=$(CONVDIR)/%)
+	sed -i -e '/^"Report-Msgid-Bugs-To:/d' $(PACKAGE).pot
 
-update-po: $(PACKAGE).pot
+update-po: generate-pot
 	for lingua in $(ALL_LINGUAS); do \
 	  if [ ! -r $$lingua.po ]; \
 	    then cp $(PACKAGE).pot $$lingua.po; \
@@ -89,6 +100,7 @@ uninstall :
 # a problem.  (msgfmt 0.10.40 doesn't handle encoding info well.)
 clean:
 	rm -f $(PACKAGE).pot *~
+	rm -fr $(CONVDIR)
 
 distclean: clean
 	rm -f Makefile


### PR DESCRIPTION
xgettext (v0.19.8.1) で翻訳データを抽出できない件の対策です。
(関連 #2 #3 #4)

テンポラリフォルダに Gauche のスクリプトをコピーして、
補間文字列の `#"～"` を `"～"` に置換し、
正規表現の `#/～/i` を `#//` に置換し、
その結果に対して xgettext を実行します。

実行方法は、これまで通り以下になります。
```
cd po
make update-po
```
(これで、WiLiKi.pot が生成されて、各 po ファイルにマージされます)

現状、置換に使っている sed の正規表現に若干抜けがあります。
( `"#"` が `""` になる ==> 問題はないはず。。。)
( `#/\\/` の最後の `/` をエスケープされた文字と判定してしまう
  ==> sed に否定後読みがないため直せなかった。。。)

あと、vi.po のメールアドレスが書き換わってしまうため、
WiLiKi.pot の `Report-Msgid-Bugs-To:`
の行を消す処理を xgettext の後に追加しています。
(この行がなければマージ時に変更しないようです)
